### PR TITLE
[PAR-V1 ]updated frequency_anchors, generate_strings, and parsons_code

### DIFF
--- a/R/frequency_anchors.R
+++ b/R/frequency_anchors.R
@@ -12,7 +12,7 @@
 #' @param call_string_col Character string. The name of the column in the data frame that contains the character string per vocalization.
 #' @param starting_frequency Numeric value. A numeric value in Hz that specifies the frequency value that will be used as a baseline for creating frequency anchors with Parsons code. For instance, if this value is 4000 Hz and the first Parsons code value is "constant", then the first frequency anchor will be 4000 Hz. The default value is 4000 Hz.
 #' @param frequency_shift Numeric value. A numeric value in Hz that specifies the frequency value that will be used to shift direction (or not). This is from the previous frequency anchor based on the Parsons code. For instance, if `frequency_shift` is 1000 Hz and the first Parsons code value is "up", then the first frequency anchor will be 5000 Hz. The default value is 1000 Hz. We have found that for total string lengths over 60 characters, it is better to use a smaller value (100 Hz). This avoids generating negative or zero values.
-#' @param section_transition Character string. The transition between sections in the Parsons code. The default value is "starting_frequency". The other option is "continuous_trajectory". In "starting_frequency" mode, the frequency value is reset to the `starting_frequency` value after each section. In "continuous_trajectory" mode, the frequency value is retained from the previous section. This can be useful for creating continuous frequency trajectories across vocalizations.
+#' @param section_transition Character string. The transition between sections in the Parsons code. The default value is "continuous_trajectory". The other option is "starting_frequency". In "starting_frequency" mode, the frequency value is reset to the `starting_frequency` value after each section. In "continuous_trajectory" mode, the frequency value is retained from the previous section. This can be useful for creating continuous frequency trajectories across vocalizations.
 #'
 #' @details `frequency_anchors()` returns the same data frame that was used as input with additional columns that hold frequency values in Hz. These columns will be used as anchors to guide frequency modulation patterns when creating synthetic audio files with the `soundgen` package. The starting frequency value is also used to end the frequency anchors. The number of frequency anchor columns in the data frame returned by the function depends on the length of each string. Currently, this function internally corrects frequency anchors that are negative or zero. It sets those values to the same value as the frequency shift (default of 1 kHz). While testing this function, we found that setting negative or zero values in the resulting data frame to 1000 Hz worked well. However, this change has not been thoroughly tested.
 #'
@@ -28,7 +28,9 @@
 #'                                    string_length = 16,
 #'                                    group_information = 8,
 #'                                    individual_information = 2,
-#'                                    random_variation = 2)
+#'                                    random_variation = 2,
+#'                                    alphabet = c("A", "B", "C")
+#'                                  )
 #'
 #' example_calls_parsons <- parsons_code(example_calls,
 #'                                       "Call",
@@ -51,7 +53,8 @@
 #'                              "Call",
 #'                              starting_frequency = 4000,
 #'                              frequency_shift = 1000,
-#'                              section_transition = "starting_frequency")
+#'                              section_transition = "continuous_trajectory"
+#'                              )
 #'
 #' glimpse(anchors)
 #'

--- a/R/generate_strings.R
+++ b/R/generate_strings.R
@@ -14,6 +14,7 @@
 #' @param group_information Integer. The number of characters that vary in the middle of the string across groups. The default is 8 characters. The user must provide an even value; negative values will result in unexpected behavior.
 #' @param individual_information Integer. The number of characters that vary in the middle of the string within groups. The default is 2 characters. The user must provide an even value; negative values will result in unexpected behavior.
 #' @param random_variation Integer. The number of characters that will vary randomly and will be appended after the individual information. The default is 2 characters. The user must provide an even value; negative values will result in unexpected behavior.
+#' @param alphabet Character vector. A vector of characters that will be used to generate the strings. The default is `c("A", "B", "C")`, which creates a 1-base Parsons code with three unique characters.
 #'
 #' @details The individual-specific and group-specific string components are combined to form the middle of a longer string. The individual-specific component of the string may not be unique to a single individual within a group, as individual distinctiveness  depends on the total number of individuals in the group, the length of the individually-specific string component, and the number of unique characters or symbols available for creating strings (which may vary depending on how users modify the function). For example, if the length of the individual-specific string component is 2 characters long and 3 unique characters are used, there will be 3^2 (or 9) possible unique individual signatures.
 #'
@@ -33,7 +34,8 @@
 #'                                    string_length = 16,
 #'                                    group_information = 8,
 #'                                    individual_information = 2,
-#'                                    random_variation = 2
+#'                                    random_variation = 2,
+#'                                    alphabet = c("A", "B", "C")
 #'                                  )
 #' glimpse(example_calls)
 #'

--- a/R/parsons_code.R
+++ b/R/parsons_code.R
@@ -32,7 +32,9 @@
 #'                                    string_length = 16,
 #'                                    group_information = 8,
 #'                                    individual_information = 2,
-#'                                    random_variation = 2)
+#'                                    random_variation = 2,
+#'                                    alphabet = c("A", "B", "C")
+#'                                  )
 #'
 #' example_calls_parsons <- parsons_code(example_calls,
 #'                                       "Call",
@@ -51,17 +53,18 @@
 #' @export parsons_code
 
 parsons_code <- function(df, string_col, global_head_col, group_head_col,
-                individual_middle_col, random_variation_col,
-                group_tail_col, global_tail_col,
-                mapping = list("A" = "up", "B" = "down", "C" = "constant"),
-                alphabet = c("A", "B", "C")) {
+                         individual_middle_col, random_variation_col,
+                         group_tail_col, global_tail_col,
+                         mapping = list("A" = "up",
+                                        "B" = "down",
+                                        "C" = "constant")) {
 
   if (!is.data.frame(df)) {
     stop("The 'df' argument must be a data frame.")
   }
-  # if (!is.list(mapping)) {
-  #   stop("The 'mapping' argument must be a list.")
-  # }
+  if (!is.list(mapping)) {
+    stop("The 'mapping' argument must be a list.")
+  }
   if (!is.character(string_col) || !is.character(global_head_col) | !is.character(group_head_col) ||
       !is.character(individual_middle_col) || !is.character(random_variation_col) ||
       !is.character(group_tail_col) || !is.character(global_tail_col)) {
@@ -81,9 +84,9 @@ parsons_code <- function(df, string_col, global_head_col, group_head_col,
         !global_tail_col %in% colnames(df)) {
     stop("One of the string columns provided does not exist in the data frame.")
   }
-  # if (length(mapping) == 0) {
-  #   stop("The 'mapping' list must contain at least one element.")
-  # }
+  if (length(mapping) == 0) {
+    stop("The 'mapping' list must contain at least one element.")
+  }
 
   # Convert all character string columns to Parsons code if group and individual information were specified (not NA)
   if (!any(is.na(df[[group_head_col]])) &&
@@ -91,37 +94,37 @@ parsons_code <- function(df, string_col, global_head_col, group_head_col,
         !any(is.na(df[[individual_middle_col]]))) {
 
     res <- df %>%
-      dplyr::mutate(Call_Parsons_Code = sapply(!!rlang::sym(string_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Global_Head_Parsons_Code = sapply(!!rlang::sym(global_head_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Group_Head_Parsons_Code = sapply(!!rlang::sym(group_head_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Individual_Middle_Parsons_Code = sapply(!!rlang::sym(individual_middle_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Random_Variation_Parsons_Code = sapply(!!rlang::sym(random_variation_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Group_Tail_Parsons_Code = sapply(!!rlang::sym(group_tail_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Global_Tail_Parsons_Code = sapply(!!rlang::sym(global_tail_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-")))
+      dplyr::mutate(Call_Parsons_Code = sapply(!!rlang::sym(string_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Global_Head_Parsons_Code = sapply(!!rlang::sym(global_head_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Group_Head_Parsons_Code = sapply(!!rlang::sym(group_head_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Individual_Middle_Parsons_Code = sapply(!!rlang::sym(individual_middle_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Random_Variation_Parsons_Code = sapply(!!rlang::sym(random_variation_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Group_Tail_Parsons_Code = sapply(!!rlang::sym(group_tail_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Global_Tail_Parsons_Code = sapply(!!rlang::sym(global_tail_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-")))
     # Convert all columns except the group membership strings if no group membership information was specified
   } else if(any(is.na(df[[group_head_col]])) & any(is.na(df[[group_tail_col]]))) {
     
 
     res <- df %>%
-      dplyr::mutate(Call_Parsons_Code = sapply(!!rlang::sym(string_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Global_Head_Parsons_Code = sapply(!!rlang::sym(global_head_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
+      dplyr::mutate(Call_Parsons_Code = sapply(!!rlang::sym(string_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Global_Head_Parsons_Code = sapply(!!rlang::sym(global_head_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
       dplyr::mutate(Group_Head_Parsons_Code = !!rlang::sym(group_head_col)) %>%
-      dplyr::mutate(Individual_Middle_Parsons_Code = sapply(!!rlang::sym(individual_middle_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Random_Variation_Parsons_Code = sapply(!!rlang::sym(random_variation_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
+      dplyr::mutate(Individual_Middle_Parsons_Code = sapply(!!rlang::sym(individual_middle_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Random_Variation_Parsons_Code = sapply(!!rlang::sym(random_variation_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
       dplyr::mutate(Group_Tail_Parsons_Code = !!rlang::sym(group_tail_col)) %>%
-      dplyr::mutate(Global_Tail_Parsons_Code = sapply(!!rlang::sym(global_tail_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-")))
+      dplyr::mutate(Global_Tail_Parsons_Code = sapply(!!rlang::sym(global_tail_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-")))
 
     # Convert all columns except the individual identity string if no individual identity information was specified
   } else if(any(is.na(df[[individual_middle_col]]))) {
     
     res <- df %>%
-      dplyr::mutate(Call_Parsons_Code = sapply(!!rlang::sym(string_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Global_Head_Parsons_Code = sapply(!!rlang::sym(global_head_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Group_Head_Parsons_Code = sapply(!!rlang::sym(group_head_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
+      dplyr::mutate(Call_Parsons_Code = sapply(!!rlang::sym(string_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Global_Head_Parsons_Code = sapply(!!rlang::sym(global_head_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Group_Head_Parsons_Code = sapply(!!rlang::sym(group_head_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
       dplyr::mutate(Individual_Middle_Parsons_Code = !!rlang::sym(individual_middle_col)) %>%
-      dplyr::mutate(Random_Variation_Parsons_Code = sapply(!!rlang::sym(random_variation_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Group_Tail_Parsons_Code = sapply(!!rlang::sym(group_tail_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-"))) %>%
-      dplyr::mutate(Global_Tail_Parsons_Code = sapply(!!rlang::sym(global_tail_col), function(string) paste(convert_to_parsons_code(string, mapping, alphabet), collapse = "-")))
+      dplyr::mutate(Random_Variation_Parsons_Code = sapply(!!rlang::sym(random_variation_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Group_Tail_Parsons_Code = sapply(!!rlang::sym(group_tail_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-"))) %>%
+      dplyr::mutate(Global_Tail_Parsons_Code = sapply(!!rlang::sym(global_tail_col), function(string) paste(convert_to_parsons_code(string, mapping), collapse = "-")))
 
   }
 
@@ -130,29 +133,6 @@ parsons_code <- function(df, string_col, global_head_col, group_head_col,
 }
 
 # Helper function to generate Parsons code for existing sequences
-convert_to_parsons_code <- function(string, mapping = NULL, alphabet = NULL) {
-  chars <- strsplit(string, NULL)[[1]]
-
-  # Use explicit mapping if given
-  if (!is.null(mapping)) {
-    return(sapply(chars, function(char) mapping[[char]], USE.NAMES = FALSE)) 
-  }
-  
-  # Otherwise use relative ordering
-  if (is.null(alphabet) || length(alphabet) < 3) {
-    stop("An alphabet of 3 or more characters must be provided if mapping is not used.")
-  }
-  indices <- match(chars, alphabet)
-  directions <- character(length(indices) - 1)
-
-  for (i in seq_along(directions)) {
-    if (indices[i + 1] > indices[i]) {
-      directions[i] <- "up"
-    } else if (indices[i + 1] < indices[i]) {
-      directions[i] <- "down"
-    } else {
-      directions[i] <- "constant"
-    }
-  }
-  return(directions)
+convert_to_parsons_code <- function(string, mapping) {
+  sapply(strsplit(string, NULL)[[1]], function(char) mapping[[char]], USE.NAMES = FALSE)
 }


### PR DESCRIPTION
Removed the 'alphabet' argument from the parsons_code and convert_to_parsons_code functions, relying solely on the explicit 'mapping' list for character-to-direction conversion. Updated documentation and examples in frequency_anchors.R, generate_strings.R, and parsons_code.R to reflect this change and clarified default values for section_transition and alphabet parameters.