### PR TITLE
[PAR-V2] update error handling unit tests for PAR-V2 functions

### DIFF
--- a/R/frequency_anchors.R
+++ b/R/frequency_anchors.R
@@ -79,6 +79,10 @@ frequency_anchors <- function(df, parsons_col, group_id_col, individual_id_col,
   if (nrow(df) == 0) {
     stop("Input data frame is empty")
   }
+  if (section_transition != "starting_frequency" &&
+      section_transition != "continuous_trajectory") {
+    stop("section_transition must be 'starting_frequency' or 'continuous_trajectory'")
+  }
   if (!all(c(parsons_col,
              group_id_col,
              individual_id_col,
@@ -86,11 +90,6 @@ frequency_anchors <- function(df, parsons_col, group_id_col, individual_id_col,
              call_string_col,
              string_structure_col) %in% colnames(df))) {
     stop("One or more columns were not found in the data frame")
-  }
-  if (section_transition != "starting_frequency" &&
-        section_transition != "continuous_trajectory") {
-    stop("section_transition must be 'starting_frequency' or ",
-         "'continuous_trajectory'")
   }
 
   # Ensure column names are case-insensitive

--- a/R/tests/testthat/test_frequency_anchors.R
+++ b/R/tests/testthat/test_frequency_anchors.R
@@ -1,26 +1,61 @@
 # Author: Raneem Samman
 # Date created: November 15, 2024
 
+rm(list = ls())
+
+# make a list of packages to install
+pkgs <- c("testthat", "soundgen", "dplyr", "stringr", "rlang", "tidyverse", "lubridate", "pbapply", "data.table")
+
+# check if the packages are installed, if not, install them
+for (pkg in pkgs) {
+  if (!require(pkg, character.only = TRUE)) {
+    install.packages(pkg, dependencies = TRUE)
+  }
+}
+# load the packages (for software development purposes)
+# lapply(pkgs, library, character.only = TRUE)
+
+# Change the path for testing to reflect where the package is installed on your local machine
+# testing_path <- "/Users/raneemsamman/Documents/GitHub/paRsynth/R" #raneem's
+testing_path <- "~/Desktop/BIRDS/GitHub_repos/paRsynth/R" #alexandra's
+
+# Change the desktop path to reflect where temporary directories for testing will be created to save files generated during testing
+desktop_path <- "~/Desktop"
+
+# Load the paRsynth functions that will be tested below
+source(file.path(testing_path, "generate_strings.R"))
+source(file.path(testing_path, "parsons_code.R"))
+source(file.path(testing_path, "frequency_anchors.R"))
+
 # Helper function to generate test data
 generate_test_data <- function() {
-  Global_head <- "AABA"
-  Group_head <- "BBCC"
-  Individual_middle <- "CCBA"
+  Global_head <- "A"
+  Group_head <- "BB"
+  Individual_head <- "C"
+  Individual_tail <- "A"
+  Individual_complete <- "CA"
+  Group_complete <- "BBCC"
   Random_variation <- "BA"
-  Group_tail <- "BBAC"
-  Global_tail <- "BBAA"
+  Group_tail <- "CC"
+  Global_tail <- "D"
+  String_structure <- "GI-II-RV-GI"
+  mapping <- list("A" = "up", "B" = "down", "C" = "constant")
   
   data.frame(
     Group_ID = 1,
     Individual_ID = 1,
     Call_ID = 1,
-    Call = paste(Global_head, Group_head, Individual_middle, Random_variation, Group_tail, Global_tail, sep = ""),
+    Call = paste(Global_head, Group_head, Individual_complete, Random_variation, Group_tail, Global_tail, sep = ""),
     Global_head = Global_head,
     Group_head = Group_head,
-    Individual_middle = Individual_middle,
+    Individual_head = Individual_head,
+    Individual_tail = Individual_tail,
+    Individual_complete = Individual_complete,
+    Group_complete = Group_complete,
     Random_variation = Random_variation,
     Group_tail = Group_tail,
-    Global_tail = Global_tail
+    Global_tail = Global_tail,
+    String_structure = String_structure
   )
 }
 # Helper function to perform Parsons Code conversion
@@ -30,11 +65,15 @@ apply_parsons_code <- function(generated_strings) {
     string_col = "Call",
     global_head_col = "Global_head",
     group_head_col = "Group_head",
-    individual_middle_col = "Individual_middle",
+    individual_head_col = "Individual_head",
+    individual_tail_col = "Individual_tail",
+    individual_complete_col = "Individual_complete",
+    group_complete_col = "Group_complete",
     random_variation_col = "Random_variation",
     group_tail_col = "Group_tail",
     global_tail_col = "Global_tail",
-    list("A" = "up", "B" = "down", "C" = "constant")
+    string_structure_col = "String_structure",
+    mapping = list("A" = "up", "B" = "down", "C" = "constant")
   )
 }
 
@@ -51,7 +90,8 @@ test_that("The function generates a data frame with multiple rows", {
     group_id_col = "Group_ID", 
     individual_id_col = "Individual_ID", 
     call_id_col = "Call_ID", 
-    call_string_col = "Call", 
+    call_string_col = "Call",
+    string_structure_col = "String_structure",
     starting_frequency = 4000, 
     frequency_shift = 1000, 
     section_transition = "continuous_trajectory"
@@ -59,7 +99,7 @@ test_that("The function generates a data frame with multiple rows", {
   # glimpse(result)
 
   # Test that the returned df (result) has the expected columns
-  expect_true(all(c("Group", "Individual", "Call_ID", "Call", "Parsons_Code") %in% colnames(result)))
+  expect_true(all(c("Group_ID", "Individual_ID", "Call_ID", "Call", "Parsons_Code") %in% colnames(result)))
   expect_true(any(grepl("Frequency", colnames(result)))) # At least one column with the word "Frequency" in the name
 
   # Test the number of frequency columns, which should be equal to the character string length plus 1 for the starting frequency

--- a/R/tests/testthat/test_frequency_anchors.R
+++ b/R/tests/testthat/test_frequency_anchors.R
@@ -37,7 +37,7 @@ generate_test_data <- function() {
   Group_complete <- "BBCC"
   Random_variation <- "BA"
   Group_tail <- "CC"
-  Global_tail <- "D"
+  Global_tail <- "B"
   String_structure <- "GI-II-RV-GI"
   mapping <- list("A" = "up", "B" = "down", "C" = "constant")
   
@@ -99,7 +99,7 @@ test_that("The function generates a data frame with multiple rows", {
   # glimpse(result)
 
   # Test that the returned df (result) has the expected columns
-  expect_true(all(c("Group_ID", "Individual_ID", "Call_ID", "Call", "Parsons_Code") %in% colnames(result)))
+  expect_true(all(c("Group", "Individual", "Call_ID", "Call", "Parsons_Code") %in% colnames(result)))
   expect_true(any(grepl("Frequency", colnames(result)))) # At least one column with the word "Frequency" in the name
 
   # Test the number of frequency columns, which should be equal to the character string length plus 1 for the starting frequency
@@ -122,38 +122,45 @@ test_that("This function shifts up, constant, and down directions frequency corr
     individual_id_col = "Individual_ID",
     call_id_col = "Call_ID",
     call_string_col = "Call",
+    string_structure_col = "String_structure",
     starting_frequency = 4000,
     frequency_shift = 1000,
     section_transition = "continuous_trajectory"
   )
   # Check the first row's frequencies (the starting frequency is 4 kHz)
-  expected_anchors <- c(4, 5, 6, 5, 6, 5, 4, 4, 4, 4, 4, 3, 4, 3, 4, 3, 2, 3, 3, 2, 1, 2, 3) * 1000
+  expected_anchors <- c(4, 5, 4, 3, 3, 4, 3, 4, 4, 4, 3) * 1000
   expect_equal(as.vector(t(result[, grep("Frequency", names(result))])), expected_anchors)
 })
 
 # 3. Unit test to check that there are no negative or zero frequencies created when generating many calls
 test_that("The function corrects negative or zero frequencies", {
   # generate strings
-  generated_strings <- generate_strings(
+  generated_strings <- suppressWarnings(generate_strings(
     n_groups = 2,
     n_individuals = 5,
     n_calls = 10,
     string_length = 40,
     group_information = 8,
     individual_information = 2,
-    random_variation = 4
-  )
+    random_variation = 4,
+    alphabet = c("A", "B", "C"),
+    string_structure = "GI-II-RV-GI"
+  ))
   # convert strings to parsons code
   parsons_results <- parsons_code(
     generated_strings,
     string_col = "Call",
     global_head_col = "Global_head",
     group_head_col = "Group_head",
-    individual_middle_col = "Individual_middle",
+    individual_head_col = "Individual_head",
+    individual_tail_col = "Individual_tail",
+    individual_complete_col = "Individual_complete",
+    group_complete_col = "Group_complete",
     random_variation_col = "Random_variation",
     group_tail_col = "Group_tail",
     global_tail_col = "Global_tail",
-    list("A" = "up", "B" = "down", "C" = "constant")
+    string_structure_col = "String_structure",
+    mapping = list("A" = "up", "B" = "down", "C" = "constant")
   )
   # generate frequency anchors with the test df
   anchors <- frequency_anchors(
@@ -163,6 +170,7 @@ test_that("The function corrects negative or zero frequencies", {
     individual_id_col = "Individual",
     call_id_col = "Call_ID",
     call_string_col = "Call",
+    string_structure_col = "String_structure",
     starting_frequency = 4000,
     frequency_shift = 1000,
     section_transition = "continuous_trajectory"

--- a/R/tests/testthat/test_frequency_anchors_error_handling.R
+++ b/R/tests/testthat/test_frequency_anchors_error_handling.R
@@ -51,6 +51,7 @@ test_that("Error handling for frequency_anchors", {
                 individual_id_col = "Individual",
                 call_id_col = "Call_ID",
                 call_string_col = "Call",
+                string_structure_col = "String_structure",
                 starting_frequency = params$starting_frequency,
                 frequency_shift = params$frequency_shift,
                 section_transition = section_transition

--- a/R/tests/testthat/test_generate_strings.R
+++ b/R/tests/testthat/test_generate_strings.R
@@ -153,7 +153,7 @@ test_that("The function generates character-based vocal strings per catergory", 
     cat("Individual middle string is:", individual_middle, "\n")
     cat("Expected individual middle length is", individual_information, "\n")
     expect_equal(nchar(individual_middle), individual_information)
-    expect_equal(individual_middle, generated_strings$Individual_middle[i])
+    expect_equal(individual_middle, generated_strings$Individual_complete[i])
   }
 })
 
@@ -220,8 +220,10 @@ test_that("The function generates strings that have the correct given string str
   
   setequal(valid_structures, unique(all_generated_structures$String_structure))
   
-  cat("Expected Valid Structures:", valid_structures)
-  cat("String structures generated:", unique(all_generated_structures$String_structure))
+  cat("Expected Valid Structures:", valid_structures, "\n")
+  cat("String structures generated:", unique(all_generated_structures$String_structure), "\n")
+  expect_identical(valid_structures, unique(all_generated_structures$String_structure))
+  setequal(valid_structures, unique(all_generated_structures$String_structure))
   
  })
 

--- a/R/tests/testthat/test_generate_strings.R
+++ b/R/tests/testthat/test_generate_strings.R
@@ -26,16 +26,18 @@ desktop_path <- "~/Desktop"
 source(file.path(testing_path, "generate_strings.R"))
 
 # Define parameters
-group_information <- 8
-individual_information <- 2
-random_variation <- 4
-global_head <- 4
-string_length <- group_information + individual_information + random_variation + (global_head * 2)
-n_calls <- 1
-n_groups <- 2
-n_individuals <- 2
-alphabet <- c("A", "B", "C")
-string_structure <- "GI-II-RV-GI"
+base_parameters <- list(
+  group_information <- 8,
+  individual_information <- 2,
+  random_variation <- 4,
+  global_head <- 4,
+  string_length <- group_information + individual_information + random_variation + (global_head * 2),
+  n_calls <- 1,
+  n_groups <- 2,
+  n_individuals <- 2,
+  alphabet <- c("A", "B", "C"),
+  string_structure <- "GI-II-RV-GI"
+)
 
 # Call the function using parameters
 generated_strings <- generate_strings(
@@ -49,6 +51,32 @@ generated_strings <- generate_strings(
   alphabet = alphabet,
   string_structure = string_structure
 )
+
+# Create a vector of all valid structures
+valid_structures <- c(
+  "GI-II-RV-GI", "GI-RV-II-GI",
+  "II-GI-RV-II", "II-RV-GI-II",
+  "GI-II-RV", "GI-RV-II",
+  "II-GI-RV", "II-RV-GI",
+  "RV-II-GI", "RV-GI-II",
+  "GI-RV-GI", "II-RV-II",
+  "GI-RV", "RV-GI",
+  "RV-II", "II-RV")
+
+# Loop the function to create calls of each valid structure
+generated_structures <- lapply(valid_structures, function(x){
+  generate_strings(
+    n_groups = n_groups,
+    n_individuals = n_individuals,
+    n_calls = n_calls,
+    string_length = string_length,
+    group_information = group_information,
+    individual_information = individual_information,
+    random_variation = random_variation,
+    alphabet = alphabet,
+    string_structure = x
+  )
+})
 
 # 1. Unit test to check string length
 test_that("The function generates strings that have the correct length", {
@@ -187,43 +215,16 @@ test_that("The function generates # of calls per individuals per social group co
 # 6. Unit test to check correct string structure
 test_that("The function generates strings that have the correct given string structure", {
   
-  # Create a vector of all valid structures
-  valid_structures <- c(
-    "GI-II-RV-GI", "GI-RV-II-GI",
-    "II-GI-RV-II", "II-RV-GI-II",
-    "GI-II-RV", "GI-RV-II",
-    "II-GI-RV", "II-RV-GI",
-    "RV-II-GI", "RV-GI-II",
-    "GI-RV-GI", "II-RV-II",
-    "GI-RV", "RV-GI",
-    "RV-II", "II-RV")
-  
-  # Loop the function to create calls of each valid structure
-  generated_structures <- lapply(valid_structures, function(x){
-    generate_strings(
-      n_groups = n_groups,
-      n_individuals = n_individuals,
-      n_calls = n_calls,
-      string_length = string_length,
-      group_information = group_information,
-      individual_information = individual_information,
-      random_variation = random_variation,
-      alphabet = alphabet,
-      string_structure = x
-    )
-  })
-  
+  # combine datasets with different different string structure into one dataframe
   all_generated_structures <- data.table::rbindlist(generated_structures)
   # glimpse(generated_structures)
   
-  expect_identical(valid_structures, unique(all_generated_structures$String_structure))
+  observed_structures <- unique(all_generated_structures$String_structure)
   
-  setequal(valid_structures, unique(all_generated_structures$String_structure))
+  expect_identical(valid_structures, observed_structures)
   
   cat("Expected Valid Structures:", valid_structures, "\n")
-  cat("String structures generated:", unique(all_generated_structures$String_structure), "\n")
-  expect_identical(valid_structures, unique(all_generated_structures$String_structure))
-  setequal(valid_structures, unique(all_generated_structures$String_structure))
+  cat("String structures generated:", observed_structures, "\n")
   
  })
 
@@ -249,6 +250,6 @@ test_that("The function outputs an error when given invalid string structure", {
     )
   }))
   
-  cat("Error thrown for these invalid structures:", invalid_structures)
+  cat("Error thrown for these invalid structures:", invalid_structures, "\n")
   
 })

--- a/R/tests/testthat/test_generate_strings_error_handling.R
+++ b/R/tests/testthat/test_generate_strings_error_handling.R
@@ -1,13 +1,17 @@
 # Author: Raneem Samman
 # Date created: December 17, 2024
 
+# Assign base parameters
 base_parameters <- list(
   n_groups = 2,
   n_individuals = 5,
   n_calls = 10,
   string_length = 16,
   group_information = 8,
-  individual_information = 2
+  individual_information = 2,
+  random_variation = 2,
+  alphabet = c("A", "B", "C"),
+  string_structure = "GI-II-RV-GI"
 )
 test_that("Error handling for generate_strings", {
 
@@ -33,7 +37,7 @@ test_that("Error handling for generate_strings", {
       n_individuals = base_parameters$n_individuals,
       n_calls = base_parameters$n_calls,
       string_length = base_parameters$string_length,
-      group_information = "8",  # String instead of numeric
+      group_information = "eight",  # String instead of numeric
       individual_information = base_parameters$individual_information
     ),
     "group_information must be numeric"
@@ -102,5 +106,20 @@ test_that("Error handling for generate_strings", {
       individual_information = base_parameters$individual_information
     ),
     "All arguments must be greater than 0"
+    
+    # Test that strings are generated with valid structure argument
+    expect_error(
+      generate_strings(
+        n_groups = base_parameters$n_groups,
+        n_individuals = base_parameters$n_individuals,
+        n_calls = base_parameters$n_calls,
+        string_length = base_parameters$string_length,
+        group_information = base_parameters$group_information,
+        individual_information = base_parameters$individual_information,
+        random_variation = base_parameters$random_variation,
+        alphabet = base_parameters$alphabet, 
+        string_structure = "GI-GI-GI" # Invalid string structure
+      ),
+      "String structure argument must use one of the 16 valid string structures"
   )
 })

--- a/R/tests/testthat/test_generate_strings_error_handling.R
+++ b/R/tests/testthat/test_generate_strings_error_handling.R
@@ -66,7 +66,7 @@ test_that("Error handling for generate_strings", {
       group_information = 7,  # Not even
       individual_information = base_parameters$individual_information
     ),
-    "group_information and individual_information must be even numbers"
+    "random_variation, group_information, and individual_information must be even numbers"
   )
 
   # Test that individual information is even
@@ -79,7 +79,7 @@ test_that("Error handling for generate_strings", {
       group_information = base_parameters$group_information,
       individual_information = 3  # Not even
     ),
-    "group_information and individual_information must be even numbers"
+    "random_variation, group_information, and individual_information must be even numbers"
   )
 
   # Test that all arguments are integers (whole numbers)
@@ -105,7 +105,9 @@ test_that("Error handling for generate_strings", {
       group_information = base_parameters$group_information,
       individual_information = base_parameters$individual_information
     ),
-    "All arguments must be greater than 0"
+    "n_groups, n_individuals, and n_calls must be greater than 0"
+    
+  )
     
     # Test that strings are generated with valid structure argument
     expect_error(
@@ -120,6 +122,8 @@ test_that("Error handling for generate_strings", {
         alphabet = base_parameters$alphabet, 
         string_structure = "GI-GI-GI" # Invalid string structure
       ),
-      "String structure argument must use one of the 16 valid string structures"
-  )
+      "Invalid string_structure. Must be one of: GI-II-RV, GI-RV-II, II-GI-RV, II-RV-GI, RV-II-GI, RV-GI-II, GI-II-RV-GI, GI-RV-II-GI, II-GI-RV-II, II-RV-GI-II, GI-RV-GI, II-RV-II, GI-RV, RV-GI, RV-II, II-RV"
+      
+    )
+    
 })

--- a/R/tests/testthat/test_parsons_code.R
+++ b/R/tests/testthat/test_parsons_code.R
@@ -27,15 +27,17 @@ source(file.path(testing_path, "generate_strings.R"))
 source(file.path(testing_path, "parsons_code.R"))
 
 # Define parameters
-n_groups <- 2
-n_individuals <- 5
-n_calls <- 10
-string_length <- 16
-group_information <- 8
-individual_information <- 2
-random_variation <- 2
-alphabet <- c("A", "B", "C")
-string_structure <- "GI-II-RV-GI"
+base_parameters <- list(
+  n_groups <- 2,
+  n_individuals <- 5,
+  n_calls <- 10,
+  string_length <- 16,
+  group_information <- 8,
+  individual_information <- 2,
+  random_variation <- 2,
+  alphabet <- c("A", "B", "C"),
+  string_structure <- "GI-II-RV-GI"
+)
 
 generated_strings <- generate_strings(
   n_groups = n_groups, 
@@ -102,18 +104,31 @@ test_that("The function generates correct parsons code", {
   Random_variation <- "BA"
   Group_tail <- "BBAC"
   Global_tail <- "BBAA"
+  Individual_head <- gsub('CC', '', Individual_middle)
+  Individual_tail <- gsub('BA', '', Individual_middle)
+  Group_complete <- c(Group_head, Group_tail)
 
   generated_strings <- data.frame(
     Call = paste(Global_head, Group_head, Individual_middle, Random_variation, Group_tail, Global_tail, sep = ""),
-    Global_head = Global_head, Group_head = Group_head, Individual_middle = Individual_middle,
+    Global_head = Global_head, Group_head = Group_head, Individual_head = Individual_head, Individual_tail = Individual_tail, Individual_middle = Individual_middle, Group_complete = Group_complete,
     Random_variation = Random_variation, Group_tail = Group_tail, Global_tail = Global_tail
   )
 
   # Convert using parsons_code
   Conversion <- parsons_code(
-    generated_strings, string_col = "Call", global_head_col = "Global_head", group_head_col = "Group_head", individual_head_col = Individual_middle/2, individual 
-    individual_complete_col = "Individual_middle", random_variation_col = "Random_variation", 
-    group_tail_col = "Group_tail", global_tail_col = "Global_tail", mapping = list("A" = "up", "B" = "down", "C" = "constant")
+    generated_strings, 
+    string_col = "Call", 
+    global_head_col = "Global_head", 
+    group_head_col = "Group_head", 
+    individual_head_col = "Individual_head", 
+    individual_tail_col = "Individual_tail", 
+    individual_complete_col = "Individual_middle", 
+    group_complete_col = "Group_complete", 
+    random_variation_col = "Random_variation", 
+    group_tail_col = "Group_tail", 
+    global_tail_col = "Global_tail", 
+    string_structure_col = "String_structure",
+    mapping = list("A" = "up", "B" = "down", "C" = "constant")
   )
   
   # Check that the generated parsons code is the same as the expected parsons code ("A" = "up", "B" = "down", "C" = "constant")

--- a/R/tests/testthat/test_parsons_code.R
+++ b/R/tests/testthat/test_parsons_code.R
@@ -1,26 +1,68 @@
 # Author: G.A. Juarez and Raneem Samman
 # Date created: December 4, 2024
 
+rm(list = ls())
+
+# make a list of packages to install
+pkgs <- c("testthat", "soundgen", "dplyr", "stringr", "rlang", "tidyverse", "lubridate", "pbapply", "data.table")
+
+# check if the packages are installed, if not, install them
+for (pkg in pkgs) {
+  if (!require(pkg, character.only = TRUE)) {
+    install.packages(pkg, dependencies = TRUE)
+  }
+}
+# load the packages (for software development purposes)
+# lapply(pkgs, library, character.only = TRUE)
+
+# Change the path for testing to reflect where the package is installed on your local machine
+# testing_path <- "/Users/raneemsamman/Documents/GitHub/paRsynth/R" #raneem's
+testing_path <- "~/Desktop/BIRDS/GitHub_repos/paRsynth/R" #alexandra's
+
+# Change the desktop path to reflect where temporary directories for testing will be created to save files generated during testing
+desktop_path <- "~/Desktop"
+
+# Load the paRsynth functions that will be tested below
+source(file.path(testing_path, "generate_strings.R"))
+source(file.path(testing_path, "parsons_code.R"))
+
 # Define parameters
 n_groups <- 2
 n_individuals <- 5
 n_calls <- 10
-globals <- 12
+string_length <- 16
 group_information <- 8
 individual_information <- 2
 random_variation <- 2
-string_length <- group_information + individual_information + random_variation + globals
+alphabet <- c("A", "B", "C")
+string_structure <- "GI-II-RV-GI"
 
 generated_strings <- generate_strings(
-  n_groups = n_groups, n_individuals = n_individuals, n_calls = n_calls, string_length = string_length, 
-  group_information = group_information, individual_information = individual_information, random_variation = random_variation
+  n_groups = n_groups, 
+  n_individuals = n_individuals, 
+  n_calls = n_calls, 
+  string_length = string_length, 
+  group_information = group_information, 
+  individual_information = individual_information, 
+  random_variation = random_variation,
+  alphabet = alphabet,
+  string_structure = string_structure
 )
 
 Conversion <- parsons_code(
   generated_strings,
-  string_col = "Call", global_head_col = "Global_head", group_head_col = "Group_head",
-  individual_middle_col = "Individual_middle", random_variation_col = "Random_variation", group_tail_col = "Group_tail",
-  global_tail_col = "Global_tail", list("A" = "up", "B" = "down", "C" = "constant")
+  string_col = "Call", 
+  global_head_col = "Global_head", 
+  group_head_col = "Group_head",
+  individual_head_col = "Individual_head",
+  individual_tail_col = "Individual_tail", 
+  individual_complete_col = "Individual_complete", 
+  group_complete_col = "Group_complete",
+  random_variation_col = "Random_variation", 
+  group_tail_col = "Group_tail",
+  global_tail_col = "Global_tail",
+  string_structure_col = "String_structure",
+  mapping = list("A" = "up", "B" = "down", "C" = "constant")
 )
 
 # Calculate the generated parsons code directions
@@ -69,9 +111,9 @@ test_that("The function generates correct parsons code", {
 
   # Convert using parsons_code
   Conversion <- parsons_code(
-    generated_strings, string_col = "Call", global_head_col = "Global_head", group_head_col = "Group_head", 
-    individual_middle_col = "Individual_middle", random_variation_col = "Random_variation", 
-    group_tail_col = "Group_tail", global_tail_col = "Global_tail", list("A" = "up", "B" = "down", "C" = "constant")
+    generated_strings, string_col = "Call", global_head_col = "Global_head", group_head_col = "Group_head", individual_head_col = Individual_middle/2, individual 
+    individual_complete_col = "Individual_middle", random_variation_col = "Random_variation", 
+    group_tail_col = "Group_tail", global_tail_col = "Global_tail", mapping = list("A" = "up", "B" = "down", "C" = "constant")
   )
   
   # Check that the generated parsons code is the same as the expected parsons code ("A" = "up", "B" = "down", "C" = "constant")

--- a/R/tests/testthat/test_parsons_code_error_handling.R
+++ b/R/tests/testthat/test_parsons_code_error_handling.R
@@ -3,29 +3,52 @@
 
 # create a data frame for testing
 test_df <- data.frame(
-    Call = c("up-down-constant", "constant-up-up"),
+    Call = c("up-down-down-up-down-up-down-constant-up-up", "down-down-up-constant-up-constant-up-up-constant-down"),
     Global = c("up", "down"),
-    Group = c("down-down-constant", "down-up-up"),
-    Individual = c("up-down-constant", "constant-up-up"),
-    Random = c("up-down-constant", "constant-up-up"),
-    groupT = c("down-down-constant", "down-up-up"),
-    tail = c("up-down-constant", "constant-up-up"),
+    Group = c("down-down-constant-up", "down-up-up-constant"),
+    Individual = c("up-down", "constant-up"),
+    Individual_head = c("up", "constant"),
+    Individual_tail = c("down", "up"),
+    Group_head = c("down-down", "down-up"),
+    Group_tail = c("constant-up", "up-constant"),
+    Random = c("up-down", "constant-up"),
     Individual = c(1, 2),
     Call_ID = c(1, 2),
     Call = c(1, 2),
+    Structure = "GI-II-RV-GI",
+    mapping = list("A" = "up", "B" = "down", "C" = "constant"),
     stringsAsFactors = FALSE
 )
 
-run_check_error <- function(df = "test_df", string_col = "Call",
-                            global_head_col = "Global", group_head_col = "Group", 
-                            individual_middle_col = "Individual", random_variation_col = "Random", 
-                            group_tail_col = "groupT", global_tail_col = "tail", mapping = list("A" = "up", "B" = "down", "C" = "constant"), 
+run_check_error <- function(df = "test_df", 
+                            string_col = "Call",
+                            global_head_col = "Global_head", 
+                            group_head_col = "Group_head", 
+                            individual_head_col = "Individual_head", 
+                            individual_tail_col = "Individual_tail",
+                            individual_complete_col = "Individual_complete",
+                            group_complete_col = "Group_complete",
+                            random_variation_col = "Random_variation", 
+                            group_tail_col = "Group_tail", 
+                            global_tail_col = "Global_tail",
+                            string_structure_col = "Structure",
+                            mapping = list("A" = "up", "B" = "down", "C" = "constant"), 
                             error_msg)
                     {
     expect_error(
-        parsons_code(df, string_col, global_head_col, group_head_col,
-                     individual_middle_col, random_variation_col,
-                     group_tail_col, global_tail_col, mapping),
+        parsons_code(df, 
+                     string_col, 
+                     global_head_col, 
+                     group_head_col, 
+                     individual_head_col, 
+                     individual_tail_col,
+                     individual_complete_col, 
+                     group_complete_col, 
+                     random_variation_col,
+                     group_tail_col, 
+                     global_tail_col, 
+                     string_structure_col,
+                     mapping),
         error_msg
     )
 }
@@ -41,6 +64,12 @@ test_that("Error handling for parsons_code", {
         df = test_df,
         mapping = "A", # not a list
         error_msg = "The 'mapping' argument must be a list."
+    )
+    # test that the string structure is valid
+    run_check_error(
+      df = test_df,
+      string_structure = "GI-GI-GI", # invalid string structure
+      error_msg = "At least one of the string columns provided does not exist in the data frame."
     )
     # test that the string column specified exists in the data frame
     invalid_string_cols <- list(
@@ -60,16 +89,21 @@ test_that("Error handling for parsons_code", {
         run_check_error(
             df = test_df,
             string_col = if (param == "string_col") value else "Call",
-            global_head_col = if (param == "global_head_col") value else "Global",
-            group_head_col = if (param == "group_head_col") value else "Group",
-            individual_middle_col = if (param == "individual_middle_col") value else "Individual",
-            random_variation_col = if (param == "random_variation_col") value else "Random",
-            group_tail_col = if (param == "group_tail_col") value else "groupT",
-            global_tail_col = if (param == "global_tail_col") value else "tail",
-            error_msg = "One of the string columns provided does not exist in the data frame."
+            global_head_col = if (param == "global_head_col") value else "Global_head",
+            group_head_col = if (param == "group_head_col") value else "Group_head",
+            individual_head_col = if (param == "individual_head_col") value else "Indiviudal_head",
+            individual_tail_col = if (param == "individual_tail_col") value else "Individual_tail",
+            individual_complete_col = if (param == "individual_complete_col") value else "Individual_complete",
+            group_complete_col = if (param == "group_complete_col") value else "Group_complete",
+            random_variation_col = if (param == "random_variation_col") value else "Random_variation",
+            group_tail_col = if (param == "group_tail_col") value else "Group_tail",
+            global_tail_col = if (param == "global_tail_col") value else "Global_tail",
+            string_structure_col = if (param == "string_structure_col") value else "Structure",
+            mapping = list("A" = "up", "B" = "down", "C" = "constant"),
+            error_msg = "At least one of the string columns provided does not exist in the data frame."
         )
     })
-
+    
     # test that the input for string_col and other columns are character strings
     invalid_cases <- list(
         list("string_col" = 1),
@@ -91,7 +125,7 @@ test_that("Error handling for parsons_code", {
             string_col = invalid_case$string_col,
             global_head_col = invalid_case$global_head_col,
             group_head_col = invalid_case$group_head_col,
-            individual_middle_col = invalid_case$individual_middle_col,
+            individual_head_col = invalid_case$individual_head_col,
             random_variation_col = invalid_case$random_variation_col,
             group_tail_col = invalid_case$group_tail_col,
             global_tail_col = invalid_case$global_tail_col,
@@ -108,6 +142,7 @@ test_that("Error handling for parsons_code", {
     run_check_error(
         df = test_df,
         mapping = list(),
-        error_msg = "The 'mapping' list must contain at least one element."
+        error_msg = "The 'mapping' argument must contain at least three elements."
     )
+    
 })


### PR DESCRIPTION
I updated the error handling unit tests for PAR-V2 functions specifically generate_strings, parsons_code, and frequency_anchors. This required editing of some functions particularly the order of conditional statements, and of specific unit tests. I would like to request your feedback to make sure my edits are on par with our standards. Thank you so much.